### PR TITLE
feat: add Supabase login page and auth integration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from "@/hooks/use-auth";
 import { ProtectedRoute } from "./lib/protected-route";
 import NotFound from "@/pages/not-found";
-import AuthPage from "@/pages/auth-page";
+import Login from "@/pages/Login";
 import HomePage from "@/pages/home-page";
 import InvoicesPage from "@/pages/invoices";
 import BudgetPage from "@/pages/budget";
@@ -16,7 +16,7 @@ function Router() {
       <ProtectedRoute path="/" component={HomePage} />
       <ProtectedRoute path="/invoices" component={InvoicesPage} />
       <ProtectedRoute path="/budget" component={BudgetPage} />
-      <Route path="/auth" component={AuthPage} />
+      <Route path="/login" component={Login} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/lib/protected-route.tsx
+++ b/client/src/lib/protected-route.tsx
@@ -24,7 +24,7 @@ export function ProtectedRoute({
   if (!user) {
     return (
       <Route path={path}>
-        <Redirect to="/auth" />
+        <Redirect to="/login" />
       </Route>
     );
   }

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export type { User } from '@supabase/supabase-js';

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Redirect, Link } from "wouter";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export default function Login() {
+  const { user, signInWithEmail, signInWithGoogle } = useAuth();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  if (user) {
+    return <Redirect to="/" />;
+  }
+
+  const handleEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    await signInWithEmail(email);
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 space-y-4">
+      <img src="/generated-icon.png" alt="Logo" className="h-16 w-16" />
+      <form onSubmit={handleEmail} className="w-full max-w-sm space-y-2">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? "Sending..." : "Sign in with Email"}
+        </Button>
+      </form>
+      <Button variant="outline" className="w-full max-w-sm" onClick={signInWithGoogle}>
+        Continue with Google
+      </Button>
+      <p className="text-sm text-muted-foreground">
+        Don't have an account? <Link href="/register" className="underline">Register</Link>
+      </p>
+    </div>
+  );
+}

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -7,7 +7,7 @@ import { PlusCircle, Receipt, Wallet, LineChart, LogOut } from "lucide-react";
 import { Invoice, Expense } from "@shared/schema";
 
 export default function HomePage() {
-  const { user, logoutMutation } = useAuth();
+  const { user, profile, signOut } = useAuth();
 
   const { data: invoices = [] } = useQuery<Invoice[]>({
     queryKey: ["/api/invoices"]
@@ -24,8 +24,8 @@ export default function HomePage() {
     <div className="min-h-screen bg-slate-50">
       <header className="bg-white border-b">
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-          <h1 className="text-2xl font-bold">Welcome, {user?.username}</h1>
-          <Button variant="ghost" onClick={() => logoutMutation.mutate()}>
+          <h1 className="text-2xl font-bold">Welcome, {profile?.username ?? user?.email}</h1>
+          <Button variant="ghost" onClick={signOut}>
             <LogOut className="h-4 w-4 mr-2" />
             Logout
           </Button>

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-icons": "^5.4.0",
     "react-resizable-panels": "^2.1.4",
     "recharts": "^2.13.0",
+    "@supabase/supabase-js": "^2.45.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.0",


### PR DESCRIPTION
## Summary
- integrate Supabase auth client and profile upsert logic
- add Login page with email/Google sign-in and register link
- update routing and home page to use new auth flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Could not find declaration files and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898e7022ab0832faedab6bb2c5bb689