### PR TITLE
Add Supabase-backed member cards on new Home page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,14 +6,14 @@ import { AuthProvider } from "@/hooks/use-auth";
 import { ProtectedRoute } from "./lib/protected-route";
 import NotFound from "@/pages/not-found";
 import AuthPage from "@/pages/auth-page";
-import HomePage from "@/pages/home-page";
+import Home from "@/pages/Home";
 import InvoicesPage from "@/pages/invoices";
 import BudgetPage from "@/pages/budget";
 
 function Router() {
   return (
     <Switch>
-      <ProtectedRoute path="/" component={HomePage} />
+      <ProtectedRoute path="/" component={Home} />
       <ProtectedRoute path="/invoices" component={InvoicesPage} />
       <ProtectedRoute path="/budget" component={BudgetPage} />
       <Route path="/auth" component={AuthPage} />

--- a/client/src/components/MemberCard.tsx
+++ b/client/src/components/MemberCard.tsx
@@ -1,0 +1,23 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { Member } from "@/lib/supabase";
+
+interface Props {
+  member: Member;
+}
+
+export function MemberCard({ member }: Props) {
+  return (
+    <div className="flex flex-col items-center">
+      <Avatar className="h-16 w-16">
+        {member.avatar_url ? (
+          <AvatarImage src={member.avatar_url} alt={member.name} />
+        ) : (
+          <AvatarFallback>{member.name.charAt(0)}</AvatarFallback>
+        )}
+      </Avatar>
+      <span className="mt-2 text-sm">{member.name}</span>
+    </div>
+  );
+}
+
+export default MemberCard;

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,0 +1,37 @@
+export interface Member {
+  id: number;
+  name: string;
+  avatar_url: string | null;
+}
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: Record<string, any>
+): Promise<T> {
+  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
+    method,
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${supabaseAnonKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`Supabase request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export function getMembers() {
+  return request<Member[]>("GET", "members?select=*");
+}
+
+export function addMember(name: string, avatar_url?: string) {
+  return request<Member>("POST", "members", { name, avatar_url });
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import MemberCard from "@/components/MemberCard";
+import { getMembers, addMember, Member } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042"];
+
+export default function Home() {
+  const [members, setMembers] = useState<Member[]>([]);
+
+  const fetchMembers = async () => {
+    try {
+      const data = await getMembers();
+      setMembers(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchMembers();
+  }, []);
+
+  const handleAddMember = async () => {
+    const name = prompt("Enter member name");
+    if (!name) return;
+    try {
+      await addMember(name);
+      fetchMembers();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const wallet = { total: 5000, income: 3000, expenses: 2000 };
+  const health = 70;
+  const pieData = [
+    { name: "Rent", value: 800 },
+    { name: "Groceries", value: 400 },
+    { name: "Utilities", value: 300 },
+    { name: "Fun", value: 200 },
+  ];
+
+  return (
+    <div className="space-y-8 p-4">
+      <div className="flex items-center gap-4 overflow-x-auto">
+        {members.map((m) => (
+          <MemberCard key={m.id} member={m} />
+        ))}
+        <Button
+          onClick={handleAddMember}
+          className="h-16 w-16 rounded-full text-xl"
+        >
+          +
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="p-4">
+          <h2 className="text-sm font-medium">Wallet Snapshot</h2>
+          <div className="mt-2 space-y-1 text-sm">
+            <div>Total Balance: ${wallet.total}</div>
+            <div>Income: ${wallet.income}</div>
+            <div>Expenses: ${wallet.expenses}</div>
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <h2 className="text-sm font-medium mb-2">Health Meter</h2>
+          <Progress value={health} />
+        </Card>
+
+        <Card className="p-4">
+          <h2 className="text-sm font-medium mb-4">Spending Breakdown</h2>
+          <ResponsiveContainer width="100%" height={200}>
+            <PieChart>
+              <Pie
+                data={pieData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                outerRadius={80}
+                label
+              >
+                {pieData.map((entry, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -38,6 +38,12 @@ export const budgets = pgTable("budgets", {
   year: integer("year").notNull(),
 });
 
+export const members = pgTable("members", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  avatarUrl: text("avatar_url"),
+});
+
 export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
   password: true,
@@ -60,8 +66,14 @@ export const insertBudgetSchema = createInsertSchema(budgets).omit({
   userId: true,
 });
 
+export const insertMemberSchema = createInsertSchema(members).omit({
+  id: true,
+});
+
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type Invoice = typeof invoices.$inferSelect;
 export type Expense = typeof expenses.$inferSelect;
 export type Budget = typeof budgets.$inferSelect;
+export type Member = typeof members.$inferSelect;
+export type InsertMember = z.infer<typeof insertMemberSchema>;


### PR DESCRIPTION
## Summary
- add `members` table schema and types
- create Supabase REST helper and MemberCard component
- build Home page with member list, wallet snapshot, health meter, and spending pie chart
- route root path to new Home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server services)*
- `npm run db:push` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_6898e8494a38832fa53b69fcf3d84737