### PR TITLE
feat: add transaction page with receipt upload

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import AuthPage from "@/pages/auth-page";
 import HomePage from "@/pages/home-page";
 import InvoicesPage from "@/pages/invoices";
 import BudgetPage from "@/pages/budget";
+import AddTransaction from "@/pages/AddTransaction";
 
 function Router() {
   return (
@@ -16,6 +17,7 @@ function Router() {
       <ProtectedRoute path="/" component={HomePage} />
       <ProtectedRoute path="/invoices" component={InvoicesPage} />
       <ProtectedRoute path="/budget" component={BudgetPage} />
+      <ProtectedRoute path="/transactions/new" component={AddTransaction} />
       <Route path="/auth" component={AuthPage} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/hooks/use-ocr-input.ts
+++ b/client/src/hooks/use-ocr-input.ts
@@ -1,0 +1,10 @@
+import { useCallback } from 'react';
+
+export function useOcrInput() {
+  const process = useCallback(async (_file: File) => {
+    console.warn('OCR processing not implemented');
+    return '';
+  }, []);
+
+  return { process };
+}

--- a/client/src/hooks/use-voice-input.ts
+++ b/client/src/hooks/use-voice-input.ts
@@ -1,0 +1,10 @@
+import { useCallback } from 'react';
+
+export function useVoiceInput() {
+  const start = useCallback(async () => {
+    console.warn('Voice input not implemented');
+    return '';
+  }, []);
+
+  return { start };
+}

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/client/src/pages/AddTransaction.tsx
+++ b/client/src/pages/AddTransaction.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  insertTransactionSchema,
+  type User,
+} from '@shared/schema';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+import {
+  Utensils,
+  Car,
+  ShoppingBag,
+  Plane,
+} from 'lucide-react';
+import { useVoiceInput } from '@/hooks/use-voice-input';
+import { useOcrInput } from '@/hooks/use-ocr-input';
+
+const categories = [
+  { name: 'Food', icon: Utensils },
+  { name: 'Travel', icon: Plane },
+  { name: 'Shopping', icon: ShoppingBag },
+  { name: 'Transport', icon: Car },
+];
+
+const formSchema = insertTransactionSchema
+  .extend({ receipt: z.any().optional() })
+  .omit({ receiptUrl: true });
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function AddTransaction() {
+  const { toast } = useToast();
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  useVoiceInput();
+  useOcrInput();
+
+  useEffect(() => {
+    supabase
+      .from('users')
+      .select('id, username')
+      .then(({ data }) => {
+        if (data) setUsers(data as unknown as User[]);
+      });
+  }, []);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      payerId: undefined,
+      category: '',
+      amount: 0,
+      note: '',
+    },
+  });
+
+  const onSubmit = async (values: FormValues) => {
+    setLoading(true);
+    try {
+      let receiptUrl: string | undefined;
+      const file = (values as any).receipt?.[0] as File | undefined;
+      if (file) {
+        const filename = `${Date.now()}-${file.name}`;
+        const { data, error } = await supabase.storage
+          .from('receipts')
+          .upload(filename, file);
+        if (error) throw error;
+        const { data: urlData } = supabase.storage
+          .from('receipts')
+          .getPublicUrl(data.path);
+        receiptUrl = urlData.publicUrl;
+      }
+      const { error: insertError } = await supabase.from('transactions').insert({
+        payer_id: values.payerId,
+        category: values.category,
+        amount: values.amount,
+        note: values.note,
+        receipt_url: receiptUrl,
+      });
+      if (insertError) throw insertError;
+      toast({ title: 'Success', description: 'Transaction recorded.' });
+      form.reset();
+    } catch (err: any) {
+      toast({
+        title: 'Error',
+        description: err.message,
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="payerId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Payer</FormLabel>
+                <FormControl>
+                  <select
+                    {...field}
+                    className="w-full border rounded p-2"
+                    onChange={(e) => field.onChange(parseInt(e.target.value))}
+                  >
+                    <option value="">Select user</option>
+                    {users.map((u) => (
+                      <option key={u.id} value={u.id}>
+                        {u.username}
+                      </option>
+                    ))}
+                  </select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="category"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Category</FormLabel>
+                <FormControl>
+                  <div className="grid grid-cols-4 gap-2">
+                    {categories.map((cat) => {
+                      const Icon = cat.icon;
+                      const selected = field.value === cat.name;
+                      return (
+                        <button
+                          type="button"
+                          key={cat.name}
+                          onClick={() => field.onChange(cat.name)}
+                          className={cn(
+                            'p-2 border rounded flex flex-col items-center',
+                            selected && 'bg-primary text-primary-foreground'
+                          )}
+                        >
+                          <Icon className="h-4 w-4 mb-1" />
+                          <span className="text-xs">{cat.name}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="amount"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Amount</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    {...field}
+                    onChange={(e) => field.onChange(parseFloat(e.target.value))}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="note"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Note</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="receipt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Receipt</FormLabel>
+                <FormControl>
+                  <Input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => field.onChange(e.target.files)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Saving...' : 'Add Transaction'}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/client/src/types/supabase-js.d.ts
+++ b/client/src/types/supabase-js.d.ts
@@ -1,0 +1,4 @@
+declare module '@supabase/supabase-js' {
+  export type SupabaseClient = any;
+  export function createClient(url: string, key: string): SupabaseClient;
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-icons": "^5.4.0",
     "react-resizable-panels": "^2.1.4",
     "recharts": "^2.13.0",
+    "@supabase/supabase-js": "^2.45.4",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.0",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -38,6 +38,16 @@ export const budgets = pgTable("budgets", {
   year: integer("year").notNull(),
 });
 
+export const transactions = pgTable("transactions", {
+  id: serial("id").primaryKey(),
+  payerId: integer("payer_id").notNull(),
+  category: text("category").notNull(),
+  amount: decimal("amount").notNull(),
+  note: text("note"),
+  receiptUrl: text("receipt_url"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
   password: true,
@@ -60,8 +70,15 @@ export const insertBudgetSchema = createInsertSchema(budgets).omit({
   userId: true,
 });
 
+export const insertTransactionSchema = createInsertSchema(transactions).omit({
+  id: true,
+  createdAt: true,
+});
+
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
 export type Invoice = typeof invoices.$inferSelect;
 export type Expense = typeof expenses.$inferSelect;
 export type Budget = typeof budgets.$inferSelect;
+export type Transaction = typeof transactions.$inferSelect;
+export type InsertTransaction = z.infer<typeof insertTransactionSchema>;


### PR DESCRIPTION
## Summary
- add AddTransaction page with payer selection, category grid, and receipt upload to Supabase
- define transactions table schema and include Supabase client setup
- stub voice and OCR hooks for future enhancements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Could not find a declaration file for module 'nodemailer')

------
https://chatgpt.com/codex/tasks/task_e_6898e84bd27c832fb7fe8ff2acf299cc